### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ author=Jason Snell
 email=jason@newrelic.com
 sentence=Libary for New Relic Insights
 paragraph=With this library you can easily submit custom events to New Relic Insights.
+category=Communication
 url=http://newrelic.com/insights
 architectures=avr,sam
 version=1.0


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library InsightsClient is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
